### PR TITLE
fix ros parameter name error

### DIFF
--- a/ros/src/imsee_ros_wrapper/src/wrapper_nodelet.cc
+++ b/ros/src/imsee_ros_wrapper/src/wrapper_nodelet.cc
@@ -370,9 +370,9 @@ public:
       config.bSlam = false;
       int index;
 
-      nh_.getParam("/indemind_node/resolution_index", index);
-      nh_.getParam("/indemind_node/framerate", config.imgFrequency);
-      nh_.getParam("/indemind_node/imu_frequency", config.imuFrequency);
+      nh_.getParam("/imsee/imsee_wrapper_node/resolution_index", index);
+      nh_.getParam("/imsee/imsee_wrapper_node/framerate", config.imgFrequency);
+      nh_.getParam("/imsee/imsee_wrapper_node/imu_frequency", config.imuFrequency);
 
       switch (index) {
       case 1:


### PR DESCRIPTION
the parameter names in ros/src/imsee_ros_wrapper/src/wrapper_nodelet.cc are wrong. parameters in config/settings.yaml take no effect. 